### PR TITLE
Implement basic MCP server tools

### DIFF
--- a/hatena-blog-suite/main.py
+++ b/hatena-blog-suite/main.py
@@ -1,0 +1,25 @@
+import argparse
+import json
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Mock main.py for Hatena Blog Suite")
+    parser.add_argument("--mode", type=str, required=True, choices=["extract", "image", "linkcheck"], help="Operation mode")
+    parser.add_argument("--hatena-id", type=str, required=True, help="Hatena ID")
+    # 想定される他の引数も追加可能
+    # parser.add_argument("--output-dir", type=str, default="output", help="Output directory")
+
+    args = parser.parse_args()
+
+    result = {
+        "message": f"Mock main.py executed successfully.",
+        "mode": args.mode,
+        "hatena_id": args.hatena_id,
+        # "output_dir": args.output_dir
+    }
+
+    # print(f"Mock main.py called with mode: {args.mode}, hatena_id: {args.hatena_id}")
+    # MCPサーバーがサブプロセスとして呼び出す場合、標準出力ではなく、
+    # 何らかの形で結果を連携する必要があるかもしれないが、
+    # 今回のMCPサーバーはコマンド文字列を返すだけなので、main.pyの出力は直接は使われない。
+    # ここでは、単に実行されたことを示すためにprintする。
+    print(json.dumps(result))

--- a/hatena-blog-suite/mcp/hatena-mcp-server/app.py
+++ b/hatena-blog-suite/mcp/hatena-mcp-server/app.py
@@ -1,0 +1,76 @@
+from flask import Flask, request, jsonify
+import subprocess
+import os
+
+app = Flask(__name__)
+
+# ルートディレクトリを基準に main.py のパスを設定
+# app.py は hatena-blog-suite/mcp/hatena-mcp-server/app.py にある
+# main.py は hatena-blog-suite/main.py にあると想定 (READMEのクイックスタートより)
+# os.path.dirname(__file__) は hatena-blog-suite/mcp/hatena-mcp-server
+# ".." で hatena-blog-suite/mcp
+# "../.." で hatena-blog-suite (これがリポジトリルートだと想定)
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+MAIN_PY_PATH = os.path.join(BASE_DIR, "main.py")
+# print(f"BASE_DIR (expected: <path_to_repo>/hatena-blog-suite): {BASE_DIR}")
+# print(f"MAIN_PY_PATH (expected: <path_to_repo>/hatena-blog-suite/main.py): {MAIN_PY_PATH}")
+# print(f"Current working directory: {os.getcwd()}")
+
+
+@app.route('/mcp', methods=['POST'])
+def mcp_handler():
+    data = request.get_json()
+    if not data or 'message' not in data:
+        return jsonify({"error": "Invalid request. 'message' field is required."}), 400
+
+    message = data['message']
+    hatena_id = os.environ.get("HATENA_ID")
+    if not hatena_id:
+        # MCPサーバー設定の例から、環境変数で渡されることを期待
+        # それがない場合は、リクエストから取得しようと試みるか、エラーとする
+        # ここでは、デモのために固定値を一時的に使うか、エラーを返す
+        # 本来は起動時に環境変数で設定されるべき
+        # return jsonify({"error": "HATENA_ID environment variable is not set."}), 500
+        # READMEのMCP Server設定例では "env": { "HATENA_ID": "your-id" } となっているので、
+        # 実際にはClaude Desktopから環境変数が渡される想定
+        # ここではダミーのIDを使うか、リクエストに含めてもらう必要がある
+        # 簡単のため、もし環境変数になければ 'your-id' を使う
+        hatena_id = data.get("hatena_id", "your-id") # 環境変数になければリクエストから、それもなければデフォルト
+
+    response_message = ""
+    command_to_run = []
+
+    if "記事を抽出してください" in message:
+        response_message = "記事抽出コマンドを実行します。"
+        # python main.py --mode extract --hatena-id your-id
+        command_to_run = ["python", MAIN_PY_PATH, "--mode", "extract", "--hatena-id", hatena_id]
+    elif "画像を生成してください" in message:
+        response_message = "画像生成コマンドを実行します。"
+        # python main.py --mode image --hatena-id your-id
+        command_to_run = ["python", MAIN_PY_PATH, "--mode", "image", "--hatena-id", hatena_id]
+    elif "リンクをチェックしてください" in message:
+        response_message = "リンクチェックコマンドを実行します。"
+        # python main.py --mode linkcheck --hatena-id your-id
+        command_to_run = ["python", MAIN_PY_PATH, "--mode", "linkcheck", "--hatena-id", hatena_id]
+    else:
+        return jsonify({"response": f"不明なコマンドです: {message}"}), 200
+
+    if command_to_run:
+        # 計画通り、ここでは実際にサブプロセスを実行せず、実行すべきコマンドを返す
+        # 実際の運用ではサブプロセスを実行するか、RQなどのキューイングシステムにジョブを投げる
+        # subprocess.Popen(command_to_run, cwd=BASE_DIR)
+        return jsonify({
+            "response": response_message,
+            "command_to_execute": " ".join(command_to_run)
+        }), 200
+    else:
+        # このケースは実際には上記のif分岐でカバーされるはず
+        return jsonify({"error": "コマンド実行準備に失敗しました。"}), 500
+
+
+if __name__ == '__main__':
+    # 環境変数を設定する例 (実際の運用では .env ファイルや起動スクリプトで行う)
+    # os.environ['HATENA_ID'] = 'test-user-id'
+    # os.environ['HATENA_API_KEY'] = 'test-api-key'
+    # os.environ['BLOG_DOMAIN'] = 'test-blog.hatenablog.com'
+    app.run(debug=True, port=5001) # MCPサーバーは通常、異なるポートで実行される想定

--- a/hatena-blog-suite/mcp/hatena-rag-mcp/__init__.py
+++ b/hatena-blog-suite/mcp/hatena-rag-mcp/__init__.py
@@ -1,0 +1,4 @@
+# This is a placeholder for the RAG (Retrieval Augmented Generation) MCP server.
+# Future implementation of the RAG MCP server will be placed here.
+# For now, it serves as a marker for the directory structure outlined in the README.
+pass


### PR DESCRIPTION
- Create directory structure for mcp server and rag mcp server as per README.
- Implement a basic Flask-based MCP server (`mcp/hatena-mcp-server/app.py`)
  - Handles requests for '記事を抽出してください', '画像を生成してください', 'リンクをチェックしてください'.
  - Returns the command string to execute `main.py` with appropriate modes.
  - Reads HATENA_ID from environment variable, fallback to request body.
- Add a placeholder `__init__.py` for `mcp/hatena-rag-mcp/`.
- Add a mock `main.py` in the root directory (`hatena-blog-suite/main.py`) for testing the MCP server.